### PR TITLE
Remove the texture work around for envinfo.totalSum

### DIFF
--- a/src/shader/shaderEnvMapSampling.js
+++ b/src/shader/shaderEnvMapSampling.js
@@ -26,7 +26,7 @@ float envMapSample( vec3 direction, EquirectHdrInfo info, out vec3 color ) {
 	vec2 uv = equirectDirectionToUv( direction );
 	color = texture2D( info.map, uv ).rgb;
 
-	float totalSum = texture2D( info.totalSum, vec2( 0.0 ) ).r;
+	float totalSum = info.totalSumWhole + info.totalSumDecimal;
 	float lum = colorToLuminance( color );
 	ivec2 resolution = textureSize( info.map, 0 );
 	float pdf = lum / totalSum;
@@ -47,7 +47,7 @@ float randomEnvMapSample( EquirectHdrInfo info, out vec3 color, out vec3 directi
 	direction = derivedDirection;
 	color = texture2D( info.map, uv ).rgb;
 
-	float totalSum = texture2D( info.totalSum, vec2( 0.0 ) ).r;
+	float totalSum = info.totalSumWhole + info.totalSumDecimal;
 	float lum = colorToLuminance( color );
 	ivec2 resolution = textureSize( info.map, 0 );
 	float pdf = lum / totalSum;

--- a/src/shader/shaderStructs.js
+++ b/src/shader/shaderStructs.js
@@ -15,7 +15,9 @@ export const shaderMaterialStructs = /* glsl */ `
 		sampler2D marginalWeights;
 		sampler2D conditionalWeights;
 		sampler2D map;
-		sampler2D totalSum;
+
+		float totalSumWhole;
+		float totalSumDecimal;
 
 	};
 


### PR DESCRIPTION
See https://twitter.com/garrettkjohnson/status/1453446051738767361 for more info on the struct precision issue on qualcomm chips. This brings us down from 17 to 16 texture units used.

There's likely a more robust way to break the 32 bit float down into components but this is good enough for now.